### PR TITLE
SNI support for Sentinel connections with TLS  

### DIFF
--- a/README.md
+++ b/README.md
@@ -929,6 +929,7 @@ The arguments passed to the constructor are different from the ones you use to c
 - `role` (optional) with a value of `slave` will return a random slave from the Sentinel group.
 - `preferredSlaves` (optional) can be used to prefer a particular slave or set of slaves based on priority. It accepts a function or array.
 - `enableTLSForSentinelMode` (optional) set to true if connecting to sentinel instances that are encrypted
+- `enableDynamicSNIForSentinelMode` (optional) set to true if Redis instances require SNI support for TLS connections
 
 ioredis **guarantees** that the node you connected to is always a master even after a failover. When a failover happens, instead of trying to reconnect to the failed node (which will be demoted to slave when it's available again), ioredis will ask sentinels for the new master node and connect to it. All commands sent during the failover are queued and will be executed when the new connection is established so that none of the commands will be lost.
 


### PR DESCRIPTION
Currently, when connecting to Redis with Sentinel, the `servername` attribute required for the SNI (Server Name Indication) TLS extension is not updated. Therefore, in cases where the connection relies on SNI, connections will fail as SNI routing cannot be properly handled. 
This issue is caused by the dynamic nature of Redis instances handled by Sentinel. Even though the `servername` attribute can be set on the `tls` object on connection, it would need to be set to the host of the current master instance which is unknown at the point of connection and can change in case of failover events. Therefore a solution which dynamically assigns the `servername` attribute according to the current master is necessary.

This PR adds a flag `enableDynamicSNIForSentinelMode` to `SentinelConnectionOptions` which dynamically sets the `servername` attribute on the Redis instance Sentinel has elected to connect to.

The flag only works in combination with `enableTLSForSentinelMode` and `tls` on the `SentinelConnectionOptions` object. 

This PR addresses this [issue](https://github.com/redis/ioredis/issues/1832).
The PR does not break existing behaviour and ensures backwards compatibility of the ioredis library. Appropriate tests and updates to the Readme are included.